### PR TITLE
Fix: correct n0res calculation for complexes with ipSAE=0 (#15)

### DIFF
--- a/ipsae.py
+++ b/ipsae.py
@@ -694,7 +694,7 @@ for chain1 in unique_chains:
         ptm_matrix_d0chn=ptm_func_vec(pae_matrix,d0chn[chain1][chain2])
 
         valid_pairs_iptm = (chains == chain2)
-        valid_pairs_matrix = (chains == chain2) & (pae_matrix < pae_cutoff)
+        valid_pairs_matrix = np.outer(chains == chain1, chains == chain2) & (pae_matrix < pae_cutoff)
 
         for i in range(numres):
 
@@ -740,7 +740,7 @@ for chain1 in unique_chains:
         ptm_matrix_d0dom = np.zeros((numres,numres))
         ptm_matrix_d0dom = ptm_func_vec(pae_matrix,d0dom[chain1][chain2])
 
-        valid_pairs_matrix = (chains == chain2) & (pae_matrix < pae_cutoff)
+        valid_pairs_matrix = np.outer(chains == chain1, chains == chain2) & (pae_matrix < pae_cutoff)
 
         # Assuming valid_pairs_matrix is already defined
         n0res_byres_all = np.sum(valid_pairs_matrix, axis=1)


### PR DESCRIPTION
**Description:**
This PR addresses the inconsistency in n0res values reported in the OUT file versus the OUT2 file for complexes with ipSAE=0.

**Problem:**
For chain pairs in complexes where ipSAE=0, the OUT file reports a positive n0res value for the asymmetric chain pair B→A, while the OUT2 file correctly shows n0res = 0 for all pairs.

**Solution:**
Update the calculation of valid_pairs_matrix in two places by changing:
`valid_pairs_matrix = (chains == chain2) & (pae_matrix < pae_cutoff)`
to
`valid_pairs_matrix = np.outer(chains == chain1, chains == chain2) & (pae_matrix < pae_cutoff)`

This change ensures consistent n0res values when ipSAE=0.

**Fixes:** #15